### PR TITLE
Drop x86 support, set support for windows, linux and macos only

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -1,7 +1,12 @@
+set_xmakever("2.5.6")
+
 add_repositories("test-repo xmake-repo")
 
 set_project("UtopiaGameEngine")
 set_version("0.0.0")
+
+set_allowedplats("windows", "linux", "macosx")
+set_allowedarchs("windows|x64", "linux|x86_64", "macosx|x86_64")
 
 add_rules("mode.debug", "mode.release")
 add_rules("plugin.vsxmake.autoupdate")


### PR DESCRIPTION
Remove x86 support because we don't care about this + glad x86 does not want to install properly on my machine so it may be the same on other machines too
Xmake version 2.5.6 minimum is needed to use `set_allowedplats` and `set_allowedarchs`