### PR TITLE
Fix interpreter destruction

### DIFF
--- a/Cardia/include/Cardia/ECS/Scene.hpp
+++ b/Cardia/include/Cardia/ECS/Scene.hpp
@@ -22,9 +22,10 @@ namespace Cardia
 
 		void destroyEntity(entt::entity entity);
 
-		void onUpdateRuntime();
+		void onRuntimeUpdate();
+		void onRuntimeStart();
+		void onRuntimeStop();
 		void onUpdateEditor(Camera& editorCamera);
-		void onCreateRuntime();
 		void onViewportResize(float width, float height);
 		Entity getEntityByUUID(const UUID& uuid);
 		inline const char* getName() const { return m_Name.c_str(); }

--- a/Cardia/include/Cardia/Scripting/EmbeddedPythonModule.hpp
+++ b/Cardia/include/Cardia/Scripting/EmbeddedPythonModule.hpp
@@ -24,7 +24,7 @@ namespace Cardia
 	template<typename T>
 	bool GetComponent(Entity& entity, py::object& cls, py::object& out)
 	{
-		auto issubclass = py::module_::import("builtins").attr("issubclass");
+		auto issubclass = ScriptEngine::getPythonBuiltins().attr("issubclass");
 		if (issubclass(cls, py::detail::get_type_handle(typeid(T), false)).cast<bool>()) {
 			out["output"] = py::cast(entity.getComponent<T>(), py::return_value_policy::reference);
 			return true;

--- a/Cardia/include/Cardia/Scripting/EmbeddedPythonModule.hpp
+++ b/Cardia/include/Cardia/Scripting/EmbeddedPythonModule.hpp
@@ -20,13 +20,11 @@ namespace pybind11::detail
 namespace Cardia
 {
 	namespace py = pybind11;
-	template<class T>
-	using type_caster = py::detail::type_caster<T>;
 
 	template<typename T>
 	bool GetComponent(Entity& entity, py::object& cls, py::object& out)
 	{
-		static auto issubclass = py::module_::import("builtins").attr("issubclass");
+		auto issubclass = py::module_::import("builtins").attr("issubclass");
 		if (issubclass(cls, py::detail::get_type_handle(typeid(T), false)).cast<bool>()) {
 			out["output"] = py::cast(entity.getComponent<T>(), py::return_value_policy::reference);
 			return true;

--- a/Cardia/include/Cardia/Scripting/ScriptEngine.hpp
+++ b/Cardia/include/Cardia/Scripting/ScriptEngine.hpp
@@ -25,21 +25,25 @@ namespace Cardia
 		std::unordered_map<std::string, ScriptData> classInstances;
 		std::vector<std::pair<py::object, std::string>> unRegisteredCallbacks;
 		std::vector<py::object> onUpdateFunctions;
+		py::object pythonBuiltins;
+		py::object cardiaPy;
 	};
 
 
 		class ScriptEngine
 		{
 		public:
-				static void init();
-				static void shutdown();
-				static void onRuntimeStart(Scene* context);
-				static void onRuntimeUpdate();
-				static Scene* getSceneContext();
-				static void registerUpdateMethod(py::object& cls, std::string& name);
-				static void registerUpdateFunction(py::object& obj);
+			static void init();
+			static void shutdown();
+			static void onRuntimeStart(Scene* context);
+			static void onRuntimeUpdate();
+			static void onRuntimeStop();
+			static Scene* getSceneContext();
+			static void registerUpdateMethod(py::object& cls, std::string& name);
+			static void registerUpdateFunction(py::object& obj);
+			static py::object& getPythonBuiltins() { return s_Data->pythonBuiltins; }
 		private:
-				static std::unique_ptr<ScriptEngineData> s_Data;
-				static ScriptData instantiatePythonClass(py::object& classObj, const std::string& id);
+			static std::unique_ptr<ScriptEngineData> s_Data;
+			static ScriptData instantiatePythonClass(py::object& classObj, const std::string& id);
 		};
 }

--- a/Cardia/src/Cardia/ECS/Scene.cpp
+++ b/Cardia/src/Cardia/ECS/Scene.cpp
@@ -41,7 +41,7 @@ namespace Cardia
 		m_Registry.destroy(entity);
 	}
 
-	void Scene::onUpdateRuntime()
+	void Scene::onRuntimeUpdate()
 	{
 		ScriptEngine::onRuntimeUpdate();
 
@@ -109,7 +109,7 @@ namespace Cardia
 		m_Registry.clear();
 	}
 
-	void Scene::onCreateRuntime()
+	void Scene::onRuntimeStart()
 	{
 		ScriptEngine::onRuntimeStart(this);
 	}
@@ -126,5 +126,10 @@ namespace Cardia
 			}
 		}
 		return result;
+	}
+
+	void Scene::onRuntimeStop()
+	{
+		ScriptEngine::onRuntimeStop();
 	}
 }

--- a/CardiaTor/src/CardiaTor.cpp
+++ b/CardiaTor/src/CardiaTor.cpp
@@ -47,7 +47,7 @@ namespace Cardia
 		}
 		if (m_EditorState == EditorState::Play)
 		{
-			m_CurrentScene->onUpdateRuntime();
+			m_CurrentScene->onRuntimeUpdate();
 		}
 
 		m_Framebuffer->unbind();
@@ -237,16 +237,18 @@ namespace Cardia
 		ImGui::SetCursorPosX((ImGui::GetWindowContentRegionMax().x- size) * 0.5f);
 		if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(static_cast<size_t>(icon->getRendererID())), ImVec2(size, size), ImVec2(0, 0), ImVec2(1, 1), 0))
 		{
-			if (m_EditorState == EditorState::Edit)
+			switch (m_EditorState)
 			{
-				m_EditorState = EditorState::Play;
-				m_CurrentScene->onCreateRuntime();
-				m_LastEditorState = SerializerUtils::SerializeScene(m_CurrentScene.get(), projectSettings().workspace);
-			}
-			else if (m_EditorState == EditorState::Play)
-			{
-				m_EditorState = EditorState::Edit;
-				reloadScene();
+				case EditorState::Edit:
+					m_EditorState = EditorState::Play;
+					m_CurrentScene->onRuntimeStart();
+					m_LastEditorState = SerializerUtils::SerializeScene(m_CurrentScene.get(), projectSettings().workspace);
+					break;
+				case EditorState::Play:
+					m_CurrentScene->onRuntimeStop();
+					m_EditorState = EditorState::Edit;
+					reloadScene();
+					break;
 			}
 		}
 		ImGui::PopStyleVar(2);

--- a/Samples/HelloCardia/Moving.py
+++ b/Samples/HelloCardia/Moving.py
@@ -1,14 +1,13 @@
-from cardia import Behavior, Input, Key, Serializable, on_key_pressed,\
-    Time, Vector3, on_mouse_clicked, Mouse, Transform
+from cardia import Behavior, Key, on_key_pressed, Time, Vector3, on_mouse_clicked, Mouse, Transform
 
 
 class Moving(Behavior):
-    def __init__(self):
-        super().__init__()
-        self.velocity: Serializable(int) = 0
+    velocity: int
+    _mouse_count: int
 
     def on_create(self):
         self.velocity = 5
+        self._mouse_count = 0
 
     def on_update(self):
         pass

--- a/cardia.py/src/cardia/component/behavior.py
+++ b/cardia.py/src/cardia/component/behavior.py
@@ -1,5 +1,8 @@
 import cardia_native as _cd
 from .transform import Transform
+from typing import TypeVar
+
+T = TypeVar("T")
 
 
 class Behavior:
@@ -14,7 +17,7 @@ class Behavior:
     def transform(self, t: Transform):
         _cd.set_native_transform(self.id, t)
 
-    def get_component(self, component_type: type):
+    def get_component(self, component_type: type[T]) -> T:
         out = {'output': None}
         _cd.get_component(self.id, component_type, out)
         return out['output']


### PR DESCRIPTION
- Fix lifetime of issubclass variable inside of GetComponent
- Free memory on runtime stopped
- Make python `get_component` generic